### PR TITLE
adding mongo connection

### DIFF
--- a/MongoModels/Database.cs
+++ b/MongoModels/Database.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using MongoDB.Bson;
+using MongoDB.Driver;
+using MongoDB.Driver.Linq;
+using MongoDB.Driver.Core;
+namespace MongoModels
+{
+    public class Database
+    {
+        public MongoClient client;
+        public IMongoDatabase db;
+        private static Database _instance;
+        public static Database Instance
+        {
+            get { return (_instance == null) ? _instance = new Database() : _instance; }
+        }
+
+        private Database()
+        {
+            var connectionString = "mongodb://jogimbel.ddns.net";
+            client = new MongoClient(connectionString);
+            db = client.GetDatabase("Pathfinda");
+
+        }
+    }
+}

--- a/MongoModels/Feats.cs
+++ b/MongoModels/Feats.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using MongoDB.Driver;
+namespace MongoModels
+{
+    class Feats
+    {
+        private static MongoModels.Database db;
+        private static IMongoCollection<BsonDocument> collection;
+        static Feats()
+        {
+            db = Database.Instance;
+            collection = db.db.GetCollection<BsonDocument>("feats");
+        }
+
+        public List<BsonDocument> Find(BsonDocument query)
+        {
+            return collection.Find(query) as List<BsonDocument>;
+        }
+
+        public List<BsonDocument> FindAlike(string name)
+        {
+            return Find(new BsonDocument { { "name", new BsonDocument { { "$regex", name }, { "$options", "i" } } } });
+        }
+    }
+}

--- a/MongoModels/MongoModels.csproj
+++ b/MongoModels/MongoModels.csproj
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{58CEACB6-7F1C-438A-B87B-3BAB23DA5B77}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MongoModels</RootNamespace>
+    <AssemblyName>MongoModels</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="MongoDB.Bson, Version=2.3.0.157, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Bson.2.3.0\lib\net45\MongoDB.Bson.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="MongoDB.Driver, Version=2.3.0.157, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Driver.2.3.0\lib\net45\MongoDB.Driver.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="MongoDB.Driver.Core, Version=2.3.0.157, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Driver.Core.2.3.0\lib\net45\MongoDB.Driver.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Database.cs" />
+    <Compile Include="Feats.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Spells.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/MongoModels/Properties/AssemblyInfo.cs
+++ b/MongoModels/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("MongoModels")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MongoModels")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("58ceacb6-7f1c-438a-b87b-3bab23da5b77")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/MongoModels/Spells.cs
+++ b/MongoModels/Spells.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using MongoDB.Driver;
+namespace MongoModels
+{
+    class Spell
+    {
+        private static MongoModels.Database db;
+        private static IMongoCollection<BsonDocument> collection;
+        static Spell()
+        {
+            db = Database.Instance;
+            collection = db.db.GetCollection<BsonDocument>("spells");
+        }
+
+        public List<BsonDocument> Find(BsonDocument query)
+        {
+            return collection.Find(query) as List<BsonDocument>;
+        }
+
+        public List<BsonDocument> FindAlike(string name)
+        {
+            return Find(new BsonDocument { { "name", new BsonDocument { { "$regex", name }, { "$options", "i" } } } });
+        }
+    }
+}
+

--- a/MongoModels/packages.config
+++ b/MongoModels/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MongoDB.Bson" version="2.3.0" targetFramework="net452" />
+  <package id="MongoDB.Driver" version="2.3.0" targetFramework="net452" />
+  <package id="MongoDB.Driver.Core" version="2.3.0" targetFramework="net452" />
+</packages>

--- a/Pathfinda.sln
+++ b/Pathfinda.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pathfinda", "Pathfinda\Pathfinda.csproj", "{09489515-9933-49AF-BA28-EE309EAB9AEE}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DataImporter", "DataImporter\DataImporter.csproj", "{0DC2EC19-0353-4E09-A9DE-30E579875700}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MongoModels", "MongoModels\MongoModels.csproj", "{58CEACB6-7F1C-438A-B87B-3BAB23DA5B77}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{0DC2EC19-0353-4E09-A9DE-30E579875700}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0DC2EC19-0353-4E09-A9DE-30E579875700}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0DC2EC19-0353-4E09-A9DE-30E579875700}.Release|Any CPU.Build.0 = Release|Any CPU
+		{58CEACB6-7F1C-438A-B87B-3BAB23DA5B77}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{58CEACB6-7F1C-438A-B87B-3BAB23DA5B77}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{58CEACB6-7F1C-438A-B87B-3BAB23DA5B77}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{58CEACB6-7F1C-438A-B87B-3BAB23DA5B77}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Add Feats and Spells classes. currently allows for `Feat|Spell#Find` and `Feat|Spellf#FindAlike`. 

`Feat#FindAlike` takes a name as a string and will regex query against the name of the feat or spell, meaning... hurray for look ahead typing!
  returns `List<BsonDocument>`

`Feat#Find` takes a BsonDocument as a query document. Used mostly has a helper method, but allows for anyone to create their own find query
  returns `List<BsonDocuments>`

Both use a singleton `Database` to connect and make queries against the MongoDB
Thank @chiccoder for the help with the singleton